### PR TITLE
Make --redir work again

### DIFF
--- a/arm_now/arm_now.py
+++ b/arm_now/arm_now.py
@@ -249,19 +249,22 @@ def check_dependencies_or_exit():
         sys.exit(1)
 
 
-re_redir = re.compile(r"(tcp|udp):\d+::\d+")
-
+re_redir = re.compile(r"(tcp|udp):\d+:\d+")
 
 def convert_redir_to_qemu_args(redir):
+    args = []
+
     for r in redir:
         if not re_redir.match(r):
             pred("ERROR: Invalid argument: --redir {}".format(r))
             print("example:")
-            print("\tredirect tcp host 8000 to guest 80: --redir tcp:8000::80")
-            print("\tredirect udp host 4444 to guest 44: --redir udp:4444::44")
+            print("\tredirect tcp host 8000 to guest 80: --redir tcp:8000:80")
+            print("\tredirect udp host 4444 to guest 44: --redir udp:4444:44")
             sys.exit(1)
-    return ''.join(map("-redir {} ".format, redir))
 
+        args.append("-nic user,hostfwd={}::{}-:{} ".format(*r.split(":")))
+
+    return "".join(args)
 
 def do_resize(size, correct):
     """ Resize filesystem.

--- a/arm_now/arm_now.py
+++ b/arm_now/arm_now.py
@@ -28,7 +28,7 @@ Commands:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Options:
   --sync                        Synchronize the current directory with the vm home.
-  --redir protocol:host::guest  Redirect the host port to the guest (example: --redir tcp:8000::80)
+  --redir protocol:host:guest  Redirect the host port to the guest (example: --redir tcp:8000:80)
   --clean                       Clean the current image before starting.
   --add-qemu-options=<options>  Add options to qemu-system-<arch>.
                      (example: --add-qemu-options="-sandbox on" to Enable seccomp mode 2 system call filter )

--- a/arm_now/arm_now.py
+++ b/arm_now/arm_now.py
@@ -252,7 +252,7 @@ def check_dependencies_or_exit():
 re_redir = re.compile(r"(tcp|udp):\d+:\d+")
 
 def convert_redir_to_qemu_args(redir):
-    args = []
+    args = ["-nic user"]
 
     for r in redir:
         if not re_redir.match(r):
@@ -262,9 +262,9 @@ def convert_redir_to_qemu_args(redir):
             print("\tredirect udp host 4444 to guest 44: --redir udp:4444:44")
             sys.exit(1)
 
-        args.append("-nic user,hostfwd={}::{}-:{} ".format(*r.split(":")))
+        args.append("hostfwd={}::{}-:{}".format(*r.split(":")))
 
-    return "".join(args)
+    return ",".join(args) + " "
 
 def do_resize(size, correct):
     """ Resize filesystem.


### PR DESCRIPTION
`-redir` has been removed from qemu :
https://wiki.qemu.org/Features/RemovedFeatures

The syntax is now a bit more complexe : `-nic user,hostfwd=tcp::8080-:80`
So I thought it would be good to replace `::` by `:` in the command line : `--redir tcp:80:8080`