### PR TITLE
fix issue https://github.com/nongiach/arm_now/issues/40

### DIFF
--- a/arm_now/utils.py
+++ b/arm_now/utils.py
@@ -4,6 +4,7 @@ import sys
 import difflib
 import contextlib
 import platform
+import distro
 
 """
 Utils functions:
@@ -36,7 +37,7 @@ pred = functools.partial(pcolor, "\x1B[31m")
 def distribution():
     system = platform.system().lower()
     if system != 'darwin':
-        return platform.linux_distribution()[0].lower()
+        return distro.linux_distribution()[0].lower()
     return system
 
 def which(filename, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ exall>=0.11
 requests>=2.18.4
 pySmartDL>=1.2.5
 docopt>=0.6.2
+python-magic>=0.4.18
+distro>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(name='arm_now',
             'requests',
             'docopt',
             'pySmartDL',
-            'python-magic'
+            'python-magic',
+            'distro'
             ],
         keywords = ['emulator', 'arm', 'mips', 'powerpc', 'x86', 'qemu']
         )


### PR DESCRIPTION
platform.linux_distribution is removed in Python 3.8
a good workaround to resolve this issue is to use distro's lib linux_distribution.