### PR TITLE
Add support for Fedora in dependency prompt

### DIFF
--- a/arm_now/arm_now.py
+++ b/arm_now/arm_now.py
@@ -233,16 +233,19 @@ def check_dependencies_or_exit():
             which("e2cp",
                 ubuntu="apt-get install e2tools",
                 arch="yaourt -S e2tools",
-                darwin="brew install e2tools gettext e2fsprogs\nbrew unlink e2fsprogs && brew link e2fsprogs -f"),
+                darwin="brew install e2tools gettext e2fsprogs\nbrew unlink e2fsprogs && brew link e2fsprogs -f",
+                fedora="dnf install e2tools"),
             which("qemu-system-arm",
                 ubuntu="apt-get install qemu\n For Kali or Ubuntu: apt-get install qemu-system",
                 kali="apt-get install qemu-system",
                 arch="pacman -S qemu-arch-extra",
-                darwin="brew install qemu"),
+                darwin="brew install qemu",
+                fedora="dnf install qemu-system-arm"),
             which("unzip",
                 ubuntu="apt-get install unzip",
                 arch="pacman -S unzip",
-                darwin="brew install unzip")
+                darwin="brew install unzip",
+                fedora="dnf install unzip")
             ]
     if not all(dependencies):
         print("requirements missing, plz install them", file=sys.stderr)


### PR DESCRIPTION
Tested on Fedora 33 prerelease:

```sh
> arm_now --help  
which: no e2cp in (/tmp/venv/bin:/home/giacomo/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/giacomo/bin)
dnf install e2tools
which: no qemu-system-arm in (/tmp/venv/bin:/home/giacomo/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/giacomo/bin)
dnf install qemu-system-arm
requirements missing, plz install them
> sudo dnf install -y qemu-system-arm                          
Last metadata expiration check: 1:38:01 ago on Fri 02 Oct 2020 11:04:25 CEST.
Dependencies resolved.
===================================================================================================================================================
 Package                                  Architecture               Version                             Repository                           Size
===================================================================================================================================================
Installing:
 qemu-system-arm                          x86_64                     2:5.1.0-5.fc33                      updates-testing                      13 k
Installing dependencies:
 qemu-system-arm-core                     x86_64                     2:5.1.0-5.fc33                      updates-testing                     4.0 M

Transaction Summary
===================================================================================================================================================
Install  2 Packages

Total download size: 4.0 M
Installed size: 15 M
Downloading Packages:
(1/2): qemu-system-arm-5.1.0-5.fc33.x86_64.rpm                                                                      29 kB/s |  13 kB     00:00    
(2/2): qemu-system-arm-core-5.1.0-5.fc33.x86_64.rpm                                                                1.8 MB/s | 4.0 MB     00:02    
---------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                              1.5 MB/s | 4.0 MB     00:02     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                           1/1 
  Installing       : qemu-system-arm-core-2:5.1.0-5.fc33.x86_64                                                                                1/2 
  Installing       : qemu-system-arm-2:5.1.0-5.fc33.x86_64                                                                                     2/2 
  Running scriptlet: qemu-system-arm-2:5.1.0-5.fc33.x86_64                                                                                     2/2 
  Verifying        : qemu-system-arm-2:5.1.0-5.fc33.x86_64                                                                                     1/2 
  Verifying        : qemu-system-arm-core-2:5.1.0-5.fc33.x86_64                                                                                2/2 

Installed:
  qemu-system-arm-2:5.1.0-5.fc33.x86_64                                 qemu-system-arm-core-2:5.1.0-5.fc33.x86_64                                

Complete!
> arm_now --help                     
which: no e2cp in (/tmp/venv/bin:/home/giacomo/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/giacomo/bin)
dnf install e2tools
requirements missing, plz install them
> sudo dnf install -y e2tools                       
Last metadata expiration check: 1:38:19 ago on Fri 02 Oct 2020 11:04:25 CEST.
Dependencies resolved.
===================================================================================================================================================
 Package                           Architecture                     Version                                 Repository                        Size
===================================================================================================================================================
Installing:
 e2tools                           x86_64                           0.1.0-2.fc33                            fedora                            52 k

Transaction Summary
===================================================================================================================================================
Install  1 Package

Total download size: 52 k
Installed size: 99 k
Downloading Packages:
e2tools-0.1.0-2.fc33.x86_64.rpm                                                                                    151 kB/s |  52 kB     00:00    
---------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                               92 kB/s |  52 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                           1/1 
  Installing       : e2tools-0.1.0-2.fc33.x86_64                                                                                               1/1 
  Running scriptlet: e2tools-0.1.0-2.fc33.x86_64                                                                                               1/1 
  Verifying        : e2tools-0.1.0-2.fc33.x86_64                                                                                               1/1 

Installed:
  e2tools-0.1.0-2.fc33.x86_64                                                                                                                      

Complete!
> arm_now --help             
arm_now.
Usage:
  arm_now list [--all]
  arm_now start [<arch>] [--clean] [-s|--sync] [--offline]
                [--autostart=<script>] [--add-qemu-options=<options>]
                [--real-source] [--redir=<port>]...
  arm_now clean
  arm_now resize <new_size> [--correct]
  arm_now install [<arch>] [--clean] [--real-source]
  arm_now show
  arm_now offline
  arm_now -h | --help
  arm_now --version
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Commands:
  list          List all available images for all cpu.
  start         Start a vm with a <arch> cpu. (default: armv5-eabi)
  resize        Resize the current rootfs. (example: arm_now resize 1G, or +1G)
  clean         Delete the current rootfs.
  install       Download, install and config a rootfs for the given <arch>. (default: armv5-eabi)
  show          Show informations about the rootfs.
  offline       Download all rootfs and kernel so arm_now can be fully runned offline.
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Options:
  --sync                        Synchronize the current directory with the vm home.
  --redir protocol:host:guest  Redirect the host port to the guest (example: --redir tcp:8000:80)
  --clean                       Clean the current image before starting.
  --add-qemu-options=<options>  Add options to qemu-system-<arch>.
                     (example: --add-qemu-options="-sandbox on" to Enable seccomp mode 2 system call filter )
  --autostart=<script>          At startup <script> is uploaded and executed inside the vm.
  --syncpath=<path>             Synchronize the <path> directory with the vm home.
  --syncroot=<path>             Synchronize the <path> directory with the vm root.
                            (Only if you need to modify the linux vm config)
  --offline                     Start with zero internet request.
  --correct                     Correct the filesystem after resize.
  -h --help                     Show this screen.
  --version                     Show version.

Defaults:
  arch          Defaults to armv5-eabi.
```