### PR TITLE
Fix issue with qemu network option name

### DIFF
--- a/arm_now/arm_now.py
+++ b/arm_now/arm_now.py
@@ -255,7 +255,7 @@ def check_dependencies_or_exit():
 re_redir = re.compile(r"(tcp|udp):\d+:\d+")
 
 def convert_redir_to_qemu_args(redir):
-    args = ["-nic user"]
+    args = ["-net user"]
 
     for r in redir:
         if not re_redir.match(r):

--- a/arm_now/arm_now.py
+++ b/arm_now/arm_now.py
@@ -255,7 +255,7 @@ def check_dependencies_or_exit():
 re_redir = re.compile(r"(tcp|udp):\d+:\d+")
 
 def convert_redir_to_qemu_args(redir):
-    args = ["-net user"]
+    args = ["-net nic -net user"]
 
     for r in redir:
         if not re_redir.match(r):


### PR DESCRIPTION
The correct option for networking seems to be `-net nic -net user`, instead of `-nic`.
This fixes #48.