### PR TITLE
Update configs to use -drive syntax everywhere, update mips64 to properly set root for kernel

### DIFF
--- a/arm_now/config.py
+++ b/arm_now/config.py
@@ -17,29 +17,29 @@ qemu_options = {
         "armv7-eabihf": ["arm", "-M vexpress-a9 -kernel {kernel} -sd {rootfs} -append 'root=/dev/mmcblk0 console=ttyAMA0 rw physmap.enabled=0 noapic'"], # check log
         # "bfin":, TODO
         # "m68k-68xxx":, TODO 
-        "m68k-coldfire": ["m68k", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "m68k-coldfire": ["m68k", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
         "microblazebe": ["microblaze", "-M petalogix-s3adsp1800 -kernel {kernel} -nographic"], # rootfs is inside the kernel file, but we also have a separated rootfs if needed
-        "microblazeel": ["microblazeel", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=tty0 rw physmap.enabled=0 noapic'"], # check log
-        "mips32": ["mips", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/hda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
-        "mips32el": ["mipsel", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/hda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "microblazeel": ["microblazeel", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=tty0 rw physmap.enabled=0 noapic'"], # check log
+        "mips32": ["mips", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/hda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "mips32el": ["mipsel", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/hda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
         "mips32r5el": ["mipsel", "-machine malta -cpu P5600 -kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/hda rw'"],
         "mips32r6el": ["mipsel", "-M malta -cpu mips32r6-generic -kernel {kernel} -drive file={rootfs},format=raw -append root=/dev/hda -net nic,model=pcnet -net user"],
-        "mips64-n32": ["mips64", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/hda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
-        "mips64el-n32": ["mips64el", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/hda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "mips64-n32": ["mips64", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "mips64el-n32": ["mips64el", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/hda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
         # "mips64r6el-n32":, TODO check log
         # "mips64r6el-n32": ["mips64el", "-machine malta -kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/hda rw console=ttyS0,'"], # check log
-        "nios2": ["nios2", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
-        "powerpc64-e5500": ["ppc64", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
-        "powerpc64-power8": ["ppc64", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
-        "powerpc64le-power8": ["ppc64", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
-        "sh-sh4": ["sh4", "-M r2d -serial vc -kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "nios2": ["nios2", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "powerpc64-e5500": ["ppc64", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "powerpc64-power8": ["ppc64", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "powerpc64le-power8": ["ppc64", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
+        "sh-sh4": ["sh4", "-M r2d -serial vc -kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # check log
         # "sparc64":, TODO check log
         # "sparc64": ["sparc64", "-M sun4u -kernel {kernel} -append 'root=/dev/sda console=ttyS0,115200' -drive file={rootfs},format=raw -net nic,model=e1000 -net user"], # this causes kernel crash
         # ":sparcv8":, TODO, check log, 
         # "sparcv8": ["sparc", "-machine SS-10 -kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0,115200' -net nic,model=lance -net user"], # error
-        # "x86-64-core-i7":["x86_64", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # old
+        # "x86-64-core-i7":["x86_64", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'"], # old
         "x86-64-core-i7" : ["x86_64", "-M pc -kernel {kernel} -drive file={rootfs},if=virtio,format=raw -append 'root=/dev/vda rw console=ttyS0' -net nic,model=virtio -net user"],
-        # "x86-core2" : ["i386", "-kernel {kernel} -hda {rootfs} -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic -net nic,model=virtio -net user'"],
+        # "x86-core2" : ["i386", "-kernel {kernel} -drive file={rootfs},format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic -net nic,model=virtio -net user'"],
         "x86-core2": ["i386", "-M pc -kernel {kernel} -drive file={rootfs},if=virtio,format=raw -append 'root=/dev/vda rw console=ttyS0' -net nic,model=virtio -net user"], # fix opkg
         "x86-i686":["i386", "-M pc -kernel {kernel} -drive file={rootfs},if=virtio,format=raw -append 'root=/dev/vda rw console=ttyS0' -net nic,model=virtio -net user"],
         "xtensa-lx60": ["xtensa", "-M lx60 -cpu dc233c -monitor null -nographic -kernel {kernel} -monitor null"]


### PR DESCRIPTION
Before the change the root= passed to the kernel for mips used /dev/hda instead of /dev/sda preventing the system from booting. I updated this as well as all of the -hda syntax to the more explicit -drive syntax while silencing the raw format warnings.

Please note, that for this fix also https://github.com/nongiach/arm_now_templates/pull/3 needs to be applied as it fixes the template tar for mips.

Before change:

```
➜  ~ arm_now start mips64-n32
[+] Installed
Tempdir /tmp/tmp391fyzti
File not found by ext2_lookup
WARNING: e2rm file already suppressed
Starting qemu-system-mips64
stty intr ^]
       export QEMU_AUDIO_DRV="none"
       qemu-system-mips64 -kernel arm_now/kernel -hda arm_now/rootfs.ext2 -append 'root=/dev/hda console=ttyS0 rw physmap.enabled=0 noapic'                -m 256M                -nographic                -serial stdio -monitor null  -nic user                                 -no-reboot
       stty intr ^c
    
WARNING: Image format was not specified for 'arm_now/rootfs.ext2' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.
Linux version 5.15.0 (br-user@runner-poenpasw-project-3290221-concurrent-0) (mips64-linux-gcc.br_real (Buildroot toolchains.bootlin.com-2021.11-1) 10.3.0, GNU ld (GNU Binutils) 2.36.1) #1 SMP Mon Dec 27 10:20:12 UTC 2021
[....]
sd 0:0:0:0: [sda] 122880 512-byte logical blocks: (62.9 MB/60.0 MiB)
scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
sd 0:0:0:0: [sda] Write Protect is off
sd 0:0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
sd 0:0:0:0: [sda] Attached SCSI disk
VFS: Cannot open root device "hda" or unknown-block(0,0): error -6
Please append a correct "root=" boot option; here are the available partitions:
```

After change:

```
➜  ~ arm_now start mips64-n32                                 
WARNING: arm_now/ already exists, use --clean to restart with a fresh filesystem
File not found by ext2_lookup
WARNING: e2rm file already suppressed
File not found by ext2_lookup
WARNING: e2rm file already suppressed
Tempdir /tmp/tmpc54b03u1
File not found by ext2_lookup
WARNING: e2rm file already suppressed
Starting qemu-system-mips64
stty intr ^]
       export QEMU_AUDIO_DRV="none"
       qemu-system-mips64 -kernel arm_now/kernel -drive file=arm_now/rootfs.ext2,format=raw -append 'root=/dev/sda console=ttyS0 rw physmap.enabled=0 noapic'                -m 256M                -nographic                -serial stdio -monitor null  -nic user                                 -no-reboot
       stty intr ^c
    
Linux version 5.15.0 (br-user@runner-poenpasw-project-3290221-concurrent-0) (mips64-linux-gcc.br_real (Buildroot toolchains.bootlin.com-2021.11-1) 10.3.0, GNU ld (GNU Binutils) 2.36.1) #1 SMP Mon Dec 27 10:20:12 UTC 2021
earlycon: uart8250 at I/O port 0x3f8 (options '38400n8')
printk: bootconsole [uart8250] enabled
CPU0 revision is: 000182a0 (MIPS 20Kc)
FPU revision is: 000f8200
OF: fdt: No chosen node found, continuing without
[....]
EXT4-fs (sda): mounting ext2 file system using the ext4 subsystem
EXT4-fs (sda): mounted filesystem without journal. Opts: (null). Quota mode: disabled.
VFS: Mounted root (ext2 filesystem) on device 8:0.
devtmpfs: mounted
Freeing unused kernel image (initmem) memory: 260K
This architecture does not have kernel memory protection.
Run /sbin/init as init process
process '/bin/busybox' started with executable stack
random: fast init done
EXT4-fs (sda): re-mounted. Opts: (null). Quota mode: disabled.
Starting syslogd: OK
Starting klogd: OK
Running sysctl: OK
Saving random seed: random: dd: uninitialized urandom read (512 bytes read)
OK
pcnet32 0000:00:0b.0 eth0: link up
press ctrl+] to kill qemu

Welcome to arm_now
buildroot login: 
```
